### PR TITLE
[FIX] Uncaught TypeError: Cannot read properties of null (reading '0')

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,14 +13,9 @@ function toHtml(url, size) {
   const re =
     /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?[^)]/;
 
+  const result = url.match(re) ? url.match(re)[0] : "";
   return (
-    "<img src=" +
-    url.match(re)[0] +
-    ' width="' +
-    size +
-    '%" height="' +
-    size +
-    '%"/><br>'
+    "<img src=" + result + ' width="' + size + '%" height="' + size + '%"/><br>'
   );
 }
 


### PR DESCRIPTION
정규식이 없을 때를 대비해서 코드를 작성해야 한다. 삼항연산자를 통해 정규식이 없을 경우 ''으로 나타내도록 했다.

참고: https://stackoverflow.com/questions/75635340/why-regex-is-giving-me-uncaught-typeerror-cannot-read-properties-of-null-readi 